### PR TITLE
rework to only use URIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ services:
 script:
   - make test-ci
 
-after_success:
-  - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-  - make push
+deploy:
+  provider: script
+  script: script/ci/deploy
+  on:
+    branch: master
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN echo http://dl-4.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositorie
 		pymemcache \
 		pymongo \
 		PyMySQL \
-		redis
+		redis \
+		awscli
 
 RUN mkdir -p /usr/src/await/bin /usr/src/await/test
 WORKDIR /usr/src/await

--- a/bin/await
+++ b/bin/await
@@ -2,6 +2,24 @@
 
 set -euo pipefail
 
+usage() {
+	cat <<'EOF'
+
+USAGE: await [-r RETRIES] [ URI | "cmd" ] [ -- EXTRA_OPTS ]
+
+Forms:
+
+	await [ -r RETRIES ] http://host:port -- [ CURL_OPTS ]
+	await [ -r RETRIES ] https://host:port -- [ CURL_OPTS ]
+	await [ -r RETRIES ] mongodb://host:port -- [ -t SELECTION_TIMEOUT ]
+	await [ -r RETRIES ] redis://host:port -- [ -t CONNECTION_TIMEOUT ]
+	await [ -r RETRIES ] memcached://host:port -- [ -t CONNECTION_TIMEOUT ]
+	await [ -r RETRIES ] mysql://user:password@host:port -- [ -t CONNECTION_TIMEOUT ]
+	await [ -r RETRIES ] dynamodb://host:port -- [ -t CONNECTION_TIMEOUT ]
+	await [ -r RETRIES ] cmd -- COMMAND [ OPTIONS ]
+EOF
+}
+
 await() {
 	local retries="${1}" counter=0
 	shift 2
@@ -67,13 +85,17 @@ main() {
 			await "${retries}" -- memcached_check "$@" "${uri}"
 			;;
 		cmd)
-			await "${retries}" -- "$@"
+			if [ $# -ne 0 ]; then
+				await "${retries}" -- "$@"
+			else
+				usage 1>&2
+				return 1
+			fi
 			;;
 		*)
-			echo "Unknown resource." 1>&2
-			echo "Usage: " 1>&2
-			# TODO: to be filled later
+			usage 1>&2
 			return 1
+			;;
 	esac
 }
 

--- a/bin/await
+++ b/bin/await
@@ -2,217 +2,71 @@
 
 set -euo pipefail
 
-main() {
-
-	local subcommand="${1:-}"
+await() {
+	local retries="${1}" counter=0
 	shift
 
-	case "${subcommand}" in
-		http)
-			local counter=0 retry=3
+	while [ "${counter}" -lt "${retry}" ]; do
+		if "$@"; then
+			echo "OK!"
+			return 0
+		else
+			((counter++))
+		fi
+	done
 
-			while getopts ":r:" opt; do
-				case "${opt}" in
-					r)
-						retry="${OPTARG}"
-						;;
-					\?)
-						echo "Invalid option: -${OPTARG}" 1>&2
-						return 1
-						;;
-					:)
-						echo "Option -${OPTARG} requires an argument." 1>&2
-						return 1
-						;;
-				esac
-			done
+	echo "failed with ${counter} retry(s)." 1>&2
+	return 1
+}
 
-			shift $((OPTIND-1))
+main() {
+	local retry=60
 
-			while [ "${counter}" -lt "${retry}" ]; do
-				if curl -s --fail "$@"; then
-					echo "OK!"
-					return 0
-				else
-					((counter++))
-				fi
-			done
+	while getopts ":r:" opt; do
+		case "${opt}" in
+			r)
+				retry="${OPTARG}"
+				;;
+			\?)
+				echo "Invalid option: -${OPTARG}" 1>&2
+				return 1
+				;;
+			:)
+				echo "Option -${OPTARG} requires an argument." 1>&2
+				return 1
+				;;
+		esac
+	done
 
-			echo "http request failed with ${counter} retry(s)." 1>&2
-			return 1
+	shift $((OPTIND-1))
+
+	local uri="${1:-}"
+	shift
+
+	case "${uri}" in
+		https?://*)
+			await "${retries}" -- curl -s fail "$@"
 			;;
-
-		mongodb)
-			local counter=0 retry=3
-
-			while getopts ":r:" opt; do
-				case "${opt}" in
-					r)
-						retry="${OPTARG}"
-						;;
-					\?)
-						echo "Invalid option: -${OPTARG} for mongo connection check." 1>&2
-						return 1
-						;;
-					:)
-						echo "Option -${OPTARG} requires an argument." 1>&2
-						return 1
-						;;
-				esac
-			done
-
-			shift $((OPTIND-1))
-
-			while [ "${counter}" -lt "${retry}" ]; do
-				if mongo_check "$@"; then
-					return 0
-				else
-					((counter++))
-				fi
-			done
-
-			echo "mongo connection request failed with ${counter} retry(s)" 1>&2
-			return 1
+		mongodb://*)
+			await "${retries}" -- mongo_check "$@"
 			;;
-
-		redis)
-			local counter=0 retry=3
-
-			while getopts ":r:" opt; do
-				case "${opt}" in
-					r)
-						retry="${OPTARG}"
-						;;
-					\?)
-						echo "Invalid option: -${OPTARG} for redis connection check." 1>&2
-						return 1
-						;;
-					:)
-						echo "Option -${OPTARG} requires an argument." 1>&2
-						return 1
-						;;
-				esac
-			done
-
-			shift $((OPTIND-1))
-
-			while [ "${counter}" -lt "${retry}" ]; do
-				if redis_check "$@"; then
-					return 0
-				else
-					((counter++))
-				fi
-			done
-
-			echo "Redis connection request failed with ${counter} retry(s)" 1>&2
-			return 1
+		redis://*)
+			await "${retries}" -- redis_check "$@"
 			;;
-
-		dynamodb)
-			local counter=0 retry=3
-
-			while getopts ":r:" opt; do
-				case "${opt}" in
-					r)
-						retry="${OPTARG}"
-						;;
-					\?)
-						echo "Invalid option: -${OPTARG} for dynamodb connection check." 1>&2
-						return 1
-						;;
-					:)
-						echo "Option -${OPTARG} requires an argument." 1>&2
-						return 1
-						;;
-				esac
-			done
-
-			shift $((OPTIND-1))
-
-			while [ "${counter}" -lt "${retry}" ]; do
-				if dynamodb_check "$@"; then
-					return 0
-				else
-					((counter++))
-				fi
-			done
-
-			echo "Dynamodb connection request failed with ${counter} retry(s)." 1>&2
-			return 1
+		dynamodb://*)
+			await "${retries}" -- dynamoddb_check "$@"
 			;;
-
-		mysql)
-			local counter=0 retry=3
-
-			while getopts ":r:" opt; do
-				case "${opt}" in
-					r)
-						retry="${OPTARG}"
-						;;
-					\?)
-						echo "Invalid option: -${OPTARG} for mysql connection check." 1>&2
-						return 1
-						;;
-					:)
-						echo "Option -${OPTARG} requires an argument." 1>&2
-						return 1
-						;;
-				esac
-			done
-
-			shift $((OPTIND-1))
-
-			while [ "${counter}" -lt "${retry}" ]; do
-				if mysql_check "$@"; then
-					return 0
-				else
-					((counter++))
-				fi
-			done
-
-			echo "Mysql connection request failed with ${counter} retry(s)." 1>&2
-			return 1
+		mysql://*)
+			await "${retries}" -- mysql_check "$@"
 			;;
-
-		memcached)
-			local counter=0 retry=3
-
-			while getopts ":r:" opt; do
-				case "${opt}" in
-					r)
-						retry="${OPTARG}"
-						;;
-					\?)
-						echo "Invalid option: -${OPTARG} for memcached connection check." 1>&2
-						return 1
-						;;
-					:)
-						echo "Option -${OPTARG} requires an argument." 1>&2
-						return 1
-						;;
-				esac
-			done
-
-			shift $((OPTIND-1))
-
-			while [ "${counter}" -lt "${retry}" ]; do
-				if memcached_check "$@"; then
-					return 0
-				else
-					((counter++))
-				fi
-			done
-
-			echo "Memcached connection request failed with ${counter} retry(s)." 1>&2
-			return 1
+		memcached://*)
+			await "${retries}" -- memcached_check "$@"
 			;;
-
 		*)
 			echo "Unknown resource." 1>&2
 			echo "Usage: " 1>&2
 			# TODO: to be filled later
 			return 1
-
 	esac
 }
 

--- a/bin/await
+++ b/bin/await
@@ -43,6 +43,10 @@ main() {
 	local uri="${1:-}"
 	shift
 
+	if [ "${1:-}" = '--' ]; then
+		shift
+	fi
+
 	case "${uri}" in
 		http://*|https://*)
 			await "${retries}" -- curl -s --fail "$@" "${uri}"
@@ -61,6 +65,9 @@ main() {
 			;;
 		memcached://*)
 			await "${retries}" -- memcached_check "$@" "${uri}"
+			;;
+		cmd)
+			await "${retries}" -- "$@"
 			;;
 		*)
 			echo "Unknown resource." 1>&2

--- a/bin/await
+++ b/bin/await
@@ -61,6 +61,9 @@ main() {
 	local uri="${1:-}"
 	shift
 
+	# Shift off the -- used to separate await options from per-case connection
+	# options. optparse does not do this in our case because we mix positional
+	# and flag arguments.
 	if [ "${1:-}" = '--' ]; then
 		shift
 	fi

--- a/bin/await
+++ b/bin/await
@@ -4,9 +4,9 @@ set -euo pipefail
 
 await() {
 	local retries="${1}" counter=0
-	shift
+	shift 2
 
-	while [ "${counter}" -lt "${retry}" ]; do
+	while [ "${counter}" -lt "${retries}" ]; do
 		if "$@"; then
 			echo "OK!"
 			return 0
@@ -20,12 +20,12 @@ await() {
 }
 
 main() {
-	local retry=60
+	local retries=60
 
 	while getopts ":r:" opt; do
 		case "${opt}" in
 			r)
-				retry="${OPTARG}"
+				retries="${OPTARG}"
 				;;
 			\?)
 				echo "Invalid option: -${OPTARG}" 1>&2
@@ -44,23 +44,23 @@ main() {
 	shift
 
 	case "${uri}" in
-		https?://*)
-			await "${retries}" -- curl -s fail "$@"
+		http://*|https://*)
+			await "${retries}" -- curl -s --fail "$@" "${uri}"
 			;;
 		mongodb://*)
-			await "${retries}" -- mongo_check "$@"
+			await "${retries}" -- mongo_check "$@" "${uri}"
 			;;
 		redis://*)
-			await "${retries}" -- redis_check "$@"
+			await "${retries}" -- redis_check "$@" "${uri}"
 			;;
 		dynamodb://*)
-			await "${retries}" -- dynamoddb_check "$@"
+			await "${retries}" -- dynamodb_check "$@" "${uri}"
 			;;
 		mysql://*)
-			await "${retries}" -- mysql_check "$@"
+			await "${retries}" -- mysql_check "$@" "${uri}"
 			;;
 		memcached://*)
-			await "${retries}" -- memcached_check "$@"
+			await "${retries}" -- memcached_check "$@" "${uri}"
 			;;
 		*)
 			echo "Unknown resource." 1>&2

--- a/bin/dynamodb_check
+++ b/bin/dynamodb_check
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2
 import argparse
+from urlparse import urlparse
 import boto3
 from botocore.client import Config
 
@@ -10,8 +11,16 @@ def main(args):
     config = Config(connect_timeout=args.timeout,
                     read_timeout=args.timeout)
 
+    if parts.port:
+        port = parts.port
+    else:
+        port = 8000
+
     client = boto3.client("dynamodb",
-                          endpoint_url="http://%s:%s" % (parts.host, parts.port)
+                          region_name="eu-west-1",
+                          aws_access_key_id="fake",
+                          aws_secret_access_key="fake",
+                          endpoint_url="http://%s:%s" % (parts.hostname, port),
                           config=config)
 
     client.list_tables()

--- a/bin/dynamodb_check
+++ b/bin/dynamodb_check
@@ -5,11 +5,13 @@ from botocore.client import Config
 
 
 def main(args):
+    parts = urlparse(args.url)
+
     config = Config(connect_timeout=args.timeout,
                     read_timeout=args.timeout)
 
     client = boto3.client("dynamodb",
-                          endpoint_url=args.url,
+                          endpoint_url="http://%s:%s" % (parts.host, parts.port)
                           config=config)
 
     client.list_tables()

--- a/bin/dynamodb_check
+++ b/bin/dynamodb_check
@@ -32,8 +32,8 @@ if __name__ == "__main__":
 
     parser.add_argument("url", nargs="?")
     parser.add_argument("-t", "--timeout", type=int, nargs=1,
-                        default=3,
-                        help="timeout in seconds (default: 3)")
+                        default=1,
+                        help="timeout in seconds (default: 1)")
 
     args = parser.parse_args()
     main(args)

--- a/bin/memcached_check
+++ b/bin/memcached_check
@@ -25,8 +25,8 @@ if __name__ == "__main__":
 
     parser.add_argument("url", nargs="?")
     parser.add_argument("-t", "--timeout", type=int, nargs=1,
-                        default=3,
-                        help="timeout in seconds (default: 3)")
+                        default=1,
+                        help="timeout in seconds (default: 1)")
 
     args = parser.parse_args()
     main(args)

--- a/bin/mongo_check
+++ b/bin/mongo_check
@@ -19,8 +19,8 @@ if __name__ == "__main__":
 
     parser.add_argument("url", nargs="?")
     parser.add_argument("-t", "--timeout", type=int, nargs=1,
-                        default=3,
-                        help="timeout in seconds (default: 3)")
+                        default=1,
+                        help="timeout in seconds (default: 1)")
 
     args = parser.parse_args()
     main(args)

--- a/bin/mysql_check
+++ b/bin/mysql_check
@@ -23,8 +23,8 @@ if __name__ == "__main__":
 
     parser.add_argument("url", nargs="?")
     parser.add_argument("-t", "--timeout", type=int, nargs=1,
-                        default=3,
-                        help="timeout in seconds (default: 3)")
+                        default=1,
+                        help="timeout in seconds (default: 1)")
 
     args = parser.parse_args()
     main(args)

--- a/bin/redis_check
+++ b/bin/redis_check
@@ -15,8 +15,8 @@ if __name__ == "__main__":
 
     parser.add_argument("url", nargs="?")
     parser.add_argument("-t", "--timeout", type=int, nargs=1,
-                        default=3,
-                        help="timeout in seconds (default: 3)")
+                        default=1,
+                        help="timeout in seconds (default: 1)")
 
     args = parser.parse_args()
     main(args)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,3 @@ services:
   await:
     image: saltside/await
     build: .
-    environment:
-      DYNAMO_DB_URL: http://dynamodb:8000
-      AWS_ACCESS_KEY_ID : test
-      AWS_SECRET_ACCESS_KEY : test
-      AWS_DEFAULT_REGION : ap-south-1

--- a/script/ci/deploy
+++ b/script/ci/deploy
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+docker login -e "${DOCKER_EMAIL}" -u "${DOCKER_USER}" -p "${DOCKER_PASS}"
+
+make push

--- a/test/await_test.bats
+++ b/test/await_test.bats
@@ -84,3 +84,13 @@
 	run await -r 2 cmd -- false
 	[ $status -eq 1 ]
 }
+
+@test "cmd without a command" {
+	run await -r 2 cmd
+	[ $status -eq 1 ]
+	echo "${output}" | grep -Fi 'usage'
+
+	run await -r 2 cmd --
+	[ $status -eq 1 ]
+	echo "${output}" | grep -Fi 'usage'
+}

--- a/test/await_test.bats
+++ b/test/await_test.bats
@@ -1,76 +1,76 @@
 #!/usr/bin/env bats
 
 @test "successful redis connection" {
-	run await redis -r 5 redis://redis
+	run await -r 5 redis://redis
 	[ $status -eq 0 ]
 }
 
 @test "unsuccessful redis connection" {
-	run await redis -r 1 redis://unknown
+	run await -r 1 redis://unknown
 	[ $status -eq 1 ]
 }
 
 @test "successful mongodb connection" {
-	run await mongodb -r 5 mongodb://mongodb
+	run await -r 5 mongodb://mongodb
 	[ $status -eq 0 ]
 }
 
 @test "unsuccessful mongodb connection" {
-	run await mongodb -r 1 mongodb://unknown
+	run await -r 1 mongodb://unknown
 	[ $status -eq 1 ]
 }
 
 @test "successful http connection" {
-	run await http -r 5 http://http
+	run await -r 5 http://http
 	[ $status -eq 0 ]
 }
 
 @test "successful http connection with extra parameters" {
-	run await http -r 2 -- http://http -m 5
+	run await -r 2 -- http://http -m 5
 	[ $status -eq 0 ]
 }
 
 @test "unsuccessful http connection" {
-	run await http http://unknown
+	run await http://unknown
 	[ $status -eq 1 ]
 }
 
 @test "unsuccessful http connection with retry" {
-	run await http -r 1 http://unkown
+	run await -r 1 http://unkown
 	[ $status -eq 1 ]
 }
 
 @test "successful dynamodb connection" {
-	run await dynamodb "${DYNAMO_DB_URL}"
+	run await dynamodb://dynamodb:8000
 	[ $status -eq 0 ]
 }
 
 @test "successful dynamodb connection with retry" {
-	run await dynamodb -r 2 "${DYNAMO_DB_URL}"
+	run await -r 2 dynamodb://dynamodb:8000
 	[ $status -eq 0 ]
 }
 
 @test "unsuccessful dynamodb connection with retry" {
-	run await dynamodb -r 1 "http://unknown:8080"
+	run await -r 1 dynamodb://unknown:8000
 	[ $status -eq 1 ]
 }
 
 @test "successful mysql connection with retry" {
-	run await mysql -r 5 mysql://root:secret@mysql:3306
+	run await -r 5 mysql://root:secret@mysql:3306
 	[ $status -eq 0 ]
 }
 
 @test "unsuccessful mysql connection with retry" {
-	run await mysql -r 1 mysql://unknown
+	run await -r 1 mysql://unknown
 	[ $status -eq 1 ]
 }
 
 @test "successful memcached connection with retry" {
-	run await memcached -r 2 tcp://memcached:11211
+	run await -r 2 memcached://memcached:11211
 	[ $status -eq 0 ]
 }
 
 @test "unsuccessful memcached connection with retry" {
-	run await memcached -r 2 tcp://unknown:11211
+	run await -r 2 memcached://unknown:11211
 	[ $status -eq 1 ]
 }

--- a/test/await_test.bats
+++ b/test/await_test.bats
@@ -94,3 +94,8 @@
 	[ $status -eq 1 ]
 	echo "${output}" | grep -Fi 'usage'
 }
+
+@test "aws CLI is included in the image" {
+	run aws --version
+	[ $status -eq 0 ]
+}

--- a/test/await_test.bats
+++ b/test/await_test.bats
@@ -74,3 +74,13 @@
 	run await -r 2 memcached://unknown:11211
 	[ $status -eq 1 ]
 }
+
+@test "successfull command with retry" {
+	run await -r 2 cmd -- true
+	[ $status -eq 0 ]
+}
+
+@test "unsuccessfull command with retry" {
+	run await -r 2 cmd -- false
+	[ $status -eq 1 ]
+}


### PR DESCRIPTION
Rework to use URIs everywhere. Changes:

* No need for a subcommand
* Change timeouts from 3 to 1 second
* Introduce a generic form that can execute any command
* The `dynamodb://` URI only works with local dynamodb., tests against production dynamodb can happen via `await cmd -- aws-cli dynamodb list-tables` with support for all AWS related options and config.
* Local dynamoDB defaults to port 8000 if none given

New usage:

```
USAGE: await [-r RETRIES] [ URI | "cmd" ] [ -- EXTRA_OPTS ]

Forms:

	await [ -r RETRIES ] http://host:port -- [ CURL_OPTS ]
	await [ -r RETRIES ] https://host:port -- [ CURL_OPTS ]
	await [ -r RETRIES ] mongodb://host:port -- [ -t SELECTION_TIMEOUT ]
	await [ -r RETRIES ] redis://host:port -- [ -t CONNECTION_TIMEOUT ]
	await [ -r RETRIES ] memcached://host:port -- [ -t CONNECTION_TIMEOUT ]
	await [ -r RETRIES ] mysql://user:password@host:port -- [ -t CONNECTION_TIMEOUT ]
	await [ -r RETRIES ] dynamodb://host:port -- [ -t CONNECTION_TIMEOUT ]
	await [ -r RETRIES ] cmd -- COMMAND [ OPTIONS ]
```